### PR TITLE
fix: disable Jekyll to serve LinkedIn SSO verification files

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,2 @@
+include:
+  - ".well-known"


### PR DESCRIPTION
## 🎯 Problem
LinkedIn SSO verification files in `.well-known/` directory returning 404 errors due to GitHub Pages Jekyll processing hiding dot-prefixed directories.

## 🔧 Solution
Add `.nojekyll` file to repository root to disable Jekyll processing and serve all files directly.

## 🚀 Result
- ✅ Fixes 404 errors for `.well-known/assetlinks.json` and `apple-app-site-association`
- ✅ Enables Universal Links and Android App Links functionality
- ✅ LinkedIn SSO verification files now publicly accessible

## 🧪 Testing
After deployment, verify files return `200 OK`:
```
curl -I https://www.purpose.hr/.well-known/assetlinks.json
curl -I https://www.purpose.hr/.well-known/apple-app-site-association
```